### PR TITLE
Fixed a couple of bugs related to the PM functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ slackAPI.prototype.getUserByEmail = function(term) {
 };
 
 slackAPI.prototype.getIM = function(term) {
-    var im = null; self = this;
+    var im = null, self = this;
     for (var i in self.slackData.ims) {
         if(self.slackData.ims[i]['user'] === term) {
             im = self.slackData.ims[i];

--- a/index.js
+++ b/index.js
@@ -234,17 +234,20 @@ slackAPI.prototype.getUserByEmail = function(term) {
 };
 
 slackAPI.prototype.getIM = function(term) {
-    var im = null;
+    var im = null; self = this;
     for (var i in self.slackData.ims) {
         if(self.slackData.ims[i]['user'] === term) {
             im = self.slackData.ims[i];
         }
     }
     if (im === null) {
-        for (var i_ in self.slackData.ims) {
-            if (self.slackData.ims[i_]['user'] === this.getUser(term).id) {
-                im = self.slackData.ims[i_];
-            }
+        var user = this.getUser(term);
+        if(user !== null) {
+          for (var i_ in self.slackData.ims) {
+              if (self.slackData.ims[i_]['user'] === user.id) {
+                  im = self.slackData.ims[i_];
+              }
+          }
         }
     }
     if (im === null) {
@@ -261,8 +264,22 @@ slackAPI.prototype.sendMsg = function(channel, text) {
     this.sendSock({'type': 'message', 'channel': channel, 'text': text});
 };
 
-slackAPI.prototype.sendPM = function(user, text) {
-    this.sendSock({'type': 'message', 'channel': this.getIM(user).id, 'text': text});
+slackAPI.prototype.sendPM = function(userID, text) {
+    var self = this;
+    channel = self.getIM(userID);
+    if(channel !== null) {
+      self.sendSock({'type': 'message', 'channel': channel.id, 'text': text});
+    } else {
+      self.reqAPI('im.open', { user : this.getUser(userID).id }, function(data){
+        if(data.ok === true) {
+          self.slackData.ims.push(data.channel);
+          self.sendSock({'type': 'message', 'channel': data.channel.id, 'text': text});
+        } else {
+          self.out('error', 'Error. Unable to create an im channel: ' + data);
+          self.emit("error", data);
+        }
+      });
+    }
 };
 
 slackAPI.prototype.events = events;


### PR DESCRIPTION
Hi! Your library is really awesome. It has been helpful in letting me creating a Slackbot very quickly.

I found a few bugs in the PM functionality and I thought I would pass my fixes along for your perusal.

### getIM function:
 * The `self` variable was never initialized. This caused the function to crash. (duh)
 * The second search loop in the getIM function (lines 244 - 247) used the value of the getUser function without checking to make sure getUser didn't return null. If the term is not a user, the function would just crash before it even got to the third search loop that checks for channel ID.

### sendPM function:
 * The sendPM originally would just crash if getIM returned null.
 * I changed the behavior so that if getIM returns null (no private IM channel is found), the function will attempt to create a new private IM channel using reqAPI. It then adds that IM channel to the list of known IM channels, and sends the message to the newly created channel.

I tested this behavior on the bot that I have been working on that needs to send lots of PM's, and it seems to work like a charm :-)
