### PR TITLE
add callback on error for the slack auth (for revoked token)

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ var errors = {
   data_type_undefined: 'data.type not defined'
 };
 
-function slackAPI(args) {
+function slackAPI(args, error_cb) {
+    error_cb = error_cb || function() {};
     var self = this;
     var authtoken = args['token'];
 
@@ -112,6 +113,7 @@ function slackAPI(args) {
 
     this.token = authtoken;
     self.reqAPI('rtm.start', {}, function (data) {
+        if (!data.ok) return error_cb(data.error);
         self.slackData.self = data.self;
         self.slackData.team = data.team;
         self.slackData.channels = data.channels;


### PR DESCRIPTION
When a token is revoked by the slack user, `slackAPI` will fail when calling `self.connectSlack(data.url...` because `data.url` is undefined
It would be nice to avoid this, and call something to notify the server that the token has been revoked