### PR TITLE
Emit errors when connectSlack callback receives them

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ slackAPI.prototype.connectSlack = function(wsurl, cb) {
                 cb(null, data);
             }
         } else {
-            cb(new Error(errors.data_type_undefined));
+            cb(new Error(errors.data_type_undefined), data);
         }
     });
 };

--- a/index.js
+++ b/index.js
@@ -124,6 +124,9 @@ function slackAPI(args, error_cb) {
             if (!err){
                 self.emit(events[data.type], data);
             }
+            else {
+                self.emit('error', data)
+            }
         });
     });
 };
@@ -184,7 +187,7 @@ slackAPI.prototype.connectSlack = function(wsurl, cb) {
     }).on('message', function(data) {
         self.out('transport', "Received: " + data);
         data = JSON.parse(data);
-        if (typeof data.type != 'undefined'){
+        if (typeof data.type !== 'undefined'){
             if (data.type === 'team_join') {
                 var messageData = data; // allow cb() to run when user.list refreshes
                 self.reqAPI('users.list', messageData, function(data) {


### PR DESCRIPTION
I ran into a use case where I needed these to be emitted, or otherwise exposed - rate limiting messages don't have a type, they just say to slow down.