### PR TITLE
Fixed issue with sendTyping prototype method

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,7 @@ slackAPI.prototype.getSlackData = function() {
 };
 
 slackAPI.prototype.sendTyping = function(channel) {
-    sendSock({'type': 'typing', channel: channel});
+    this.sendSock({'type': 'typing', channel: channel});
     return this;
 };
 


### PR DESCRIPTION
The sendTyping method wasn't using the "this" keyword so calls to the method were failing. This pull request fixes that issue.  