### PR TITLE
fix lowerCase is not a function

### DIFF
--- a/examples/example_bot.js
+++ b/examples/example_bot.js
@@ -38,7 +38,7 @@ slack.on('message', function (data) {
         }
 
         // Switch to check which command has been requested.
-        switch (command[0].lowerCase()) {
+        switch (command[0].toLowerCase()) {
             // If hello
             case 'hello':
                 // Send message


### PR DESCRIPTION
```
c:\download\slackbotapi\example_bot.js:41
        switch (command[0].lowerCase()) {
                           ^

TypeError: command[0].lowerCase is not a function
    at slackAPI.<anonymous> (c:\download\slackbotapi\example_bot.js:41:28)
```